### PR TITLE
Composition API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Lens composition:
 val lens1: Person ~~> Address = lens(_: Person)(_.address)
 val lens2: Address ~~> String = lens(_: Address)(_.street.name)
 
-val lens3: Person ~~> String = lens1 composeLens lens2
+val lens3: Person ~~> String = lens1 andThenLense lens2 // or lens2 composeLens lens1
 val p5: Person = lens3(person)(_.toLowerCase)
 ```
 

--- a/src/main/scala/com/github/pathikrit/sauron/package.scala
+++ b/src/main/scala/com/github/pathikrit/sauron/package.scala
@@ -35,6 +35,7 @@ package object sauron {
   }
 
   implicit class LensOps[A, B](val f: A ~~> B) extends AnyVal {
-    def composeLens[C](g: B ~~> C): A ~~> C = x => y => f(x)(g(_)(y))
+    def andThenLens[C](g: B ~~> C): A ~~> C = x => y => f(x)(g(_)(y))
+    def composeLens[C](g: C ~~> A): C ~~> B = x => y => g(x)(f(_)(y))
   }
 }

--- a/src/test/scala/com/github/pathikrit/sauron/suites/SauronSuite.scala
+++ b/src/test/scala/com/github/pathikrit/sauron/suites/SauronSuite.scala
@@ -29,8 +29,11 @@ class SauronSuite extends FunSuite {
     val lens2: Address ~~> Street = lens(_: Address)(_.street)
     val lens3: Street ~~> String = lens(_: Street)(_.name)
 
-    val lens4: Person ~~> String = lens1 composeLens lens2 composeLens lens3
+    val lens4: Person ~~> String = lens1 andThenLens lens2 andThenLens lens3
     lens4(p1)(_.toLowerCase) shouldEqual p3
+
+    val lens5: Person ~~> String = lens3 composeLens lens2 composeLens lens1
+    lens5(p1)(_.toLowerCase) shouldEqual p3
 
     "lens(p1)(_.address.zip)(_.toUpperCase)" should compile
     "lens(p1)(_.address.zip.length)(_ + 1)" shouldNot compile


### PR DESCRIPTION
Unfortunately, this is a breaking API change but I believe this should be done at early stage.

This PR adds new method for lens composition: `andThenLens`. It actually renames `composeLens` to `andThenLens` to make the API feels natural.
